### PR TITLE
feat: allow bulk invalidation

### DIFF
--- a/.emdaer/.offline/plugin-contributors-details-github/contributors-data.json
+++ b/.emdaer/.offline/plugin-contributors-details-github/contributors-data.json
@@ -27,7 +27,7 @@
     "bio": "Engineer and programmer focused on online applications.",
     "public_repos": 67,
     "public_gists": 35,
-    "followers": 88,
+    "followers": 90,
     "following": 45,
     "created_at": "2011-10-20T14:27:43Z",
     "updated_at": "2018-06-22T10:20:03Z"
@@ -58,11 +58,11 @@
     "email": null,
     "hireable": null,
     "bio": "Software architect with an interest in distributed systems and elegant solutions.",
-    "public_repos": 78,
+    "public_repos": 80,
     "public_gists": 38,
-    "followers": 50,
+    "followers": 51,
     "following": 12,
     "created_at": "2010-10-20T16:40:28Z",
-    "updated_at": "2018-07-25T21:18:08Z"
+    "updated_at": "2018-09-28T00:25:10Z"
   }
 ]


### PR DESCRIPTION
Invalidate cache entries as a soft alternative to deletion. This
will have a very similar effect but release some strain from the
Redis engine. The expired cache entries will be collected and evicted
when Redis decides it is best