### PR TITLE
feat: add a batchDeleteWithTags utility to RedisTaggedCache class

### DIFF
--- a/.emdaer/.offline/plugin-contributors-details-github/contributors-data.json
+++ b/.emdaer/.offline/plugin-contributors-details-github/contributors-data.json
@@ -30,7 +30,7 @@
     "followers": 98,
     "following": 45,
     "created_at": "2011-10-20T14:27:43Z",
-    "updated_at": "2019-01-21T15:03:13Z"
+    "updated_at": "2019-02-06T21:57:33Z"
   },
   {
     "login": "elliotttf",

--- a/.emdaer/.offline/plugin-contributors-details-github/contributors-data.json
+++ b/.emdaer/.offline/plugin-contributors-details-github/contributors-data.json
@@ -25,12 +25,12 @@
     "email": null,
     "hireable": null,
     "bio": "Engineer and programmer focused on online applications.",
-    "public_repos": 67,
-    "public_gists": 35,
-    "followers": 90,
+    "public_repos": 70,
+    "public_gists": 36,
+    "followers": 98,
     "following": 45,
     "created_at": "2011-10-20T14:27:43Z",
-    "updated_at": "2018-06-22T10:20:03Z"
+    "updated_at": "2019-01-21T15:03:13Z"
   },
   {
     "login": "elliotttf",
@@ -58,9 +58,9 @@
     "email": null,
     "hireable": null,
     "bio": "Software architect with an interest in distributed systems and elegant solutions.",
-    "public_repos": 80,
+    "public_repos": 81,
     "public_gists": 38,
-    "followers": 51,
+    "followers": 52,
     "following": 12,
     "created_at": "2010-10-20T16:40:28Z",
     "updated_at": "2018-09-28T00:25:10Z"

--- a/src/RedisTaggedCache.js
+++ b/src/RedisTaggedCache.js
@@ -369,9 +369,7 @@ class RedisTaggedCache extends TaggedCache {
         return (
           intersection
             // We need to remove the Redis prefix. This is un-ideal.
-            .map(key =>
-              key.replace(new RegExp(`^${this.store.options.keyPrefix}`), '')
-            )
+            .map(key => key.replace(this.keyPrefixPattern, ''))
         );
       });
   }

--- a/src/RedisTaggedCache.js
+++ b/src/RedisTaggedCache.js
@@ -12,17 +12,17 @@ type MemberPage = { members: Array<string>, cursor: number };
 class RedisTaggedCache extends TaggedCache {
   /**
    * RegExp pattern that can be used to find and replace prefixes in tag keys.
-   * 
-   * @var {RegExp} 
+   *
+   * @var {RegExp}
    */
-   keyPrefixPattern: RegExp;
+  keyPrefixPattern: RegExp;
 
-   /**
-    * {@inheritdoc}
-    */
+  /**
+   * {@inheritdoc}
+   */
   constructor(...args: any) {
     super(...args);
-    this.keyPrefixPattern = new RegExp(`^${this.store.options.keyPrefix}`); 
+    this.keyPrefixPattern = new RegExp(`^${this.store.options.keyPrefix}`);
   }
 
   /**

--- a/src/RedisTaggedCache.js
+++ b/src/RedisTaggedCache.js
@@ -11,6 +11,21 @@ type MemberPage = { members: Array<string>, cursor: number };
 
 class RedisTaggedCache extends TaggedCache {
   /**
+   * RegExp pattern that can be used to find and replace prefixes in tag keys.
+   * 
+   * @var {RegExp} 
+   */
+   keyPrefixPattern: RegExp;
+
+   /**
+    * {@inheritdoc}
+    */
+  constructor(...args: any) {
+    super(...args);
+    this.keyPrefixPattern = new RegExp(`^${this.store.options.keyPrefix}`); 
+  }
+
+  /**
    * Store an item in the cache.
    *
    * Takes the same arguments as ioredis set calls.
@@ -156,7 +171,7 @@ class RedisTaggedCache extends TaggedCache {
 
     // Process given keys.
     const keysToDelete = _.map(members, key =>
-      key.replace(new RegExp(`^${this.store.options.keyPrefix}`), '')
+      key.replace(this.keyPrefixPattern, '')
     );
 
     await Promise.all([

--- a/src/RedisTaggedCache.js
+++ b/src/RedisTaggedCache.js
@@ -114,9 +114,9 @@ class RedisTaggedCache extends TaggedCache {
    *
    * {@link https://redis.io/commands/scan}
    */
-  async batchDeleteWithTags() {
+  async batchDeleteWithTags(): Promise<Array<() => void>> {
     const tagIds = await this.tags.tagIds();
-    await Promise.all(
+    return Promise.all(
       _.map(tagIds, tagId =>
         this.trampoline(
           this.batchDeleteTagMembers.bind(this, this.referenceKey(tagId))

--- a/src/RedisTaggedCache.test.js
+++ b/src/RedisTaggedCache.test.js
@@ -84,4 +84,67 @@ describe('RedisTaggedCache', () => {
       expect(res).toHaveLength(0);
     });
   });
+
+  test('It can get a single page of tag members', async () => {
+    expect.assertions(2);
+    const cursor = 100;
+    const members = ['test-tag'];
+    sut.debounce = jest.fn().mockResolvedValue([cursor, members]);
+
+    const resolved = await sut.getMemberPage('testKey');
+    expect(sut.debounce).toHaveBeenCalledWith('sscan', 'testKey', 0);
+    expect(resolved).toEqual({
+      cursor,
+      members,
+    });
+  });
+
+  test('It can batch delete tag members', async () => {
+    expect.assertions(5);
+    const tagId = 'tag-id';
+    const cursor = 100;
+    const members = ['the-prefix!::test-tag', 'the-prefix!::test-tag-2'];
+    sut.getMemberPage = jest.fn().mockResolvedValue({ cursor, members });
+    sut.deleteMultiple = jest.fn();
+    sut.store.srem = jest.fn();
+
+    const resolved = await sut.batchDeleteTagMembers(tagId, 0);
+
+    expect(sut.store.srem).toHaveBeenCalledTimes(2);
+    expect(sut.store.srem).toHaveBeenLastCalledWith(tagId, 'test-tag-2');
+    expect(sut.deleteMultiple).toHaveBeenCalledWith(['test-tag', 'test-tag-2']);
+    expect(resolved).not.toBeNull();
+
+    sut.getMemberPage = jest.fn().mockResolvedValue({ cursor: 0, members });
+    const newResolved = await resolved();
+    expect(newResolved).toBeNull();
+  });
+
+  test('Its trampoline utility method behaves as expected', async () => {
+    expect.assertions(1);
+    const count = 3;
+    const cb = jest.fn((iterations = 1) => {
+      if (iterations === count) {
+        return null;
+      }
+
+      return cb.bind(null, iterations + 1);
+    });
+
+    await sut.trampoline(cb);
+    expect(cb).toHaveBeenCalledTimes(count);
+  });
+
+  test('It can batch delete members for all tags', async () => {
+    const members = ['tag-id-1', 'tag-id-2'];
+    sut.tags.tagIds = jest.fn().mockResolvedValue(['tag-set-1', 'tag-set-2']);
+    sut.getMemberPage = jest.fn().mockResolvedValue({ cursor: 0, members });
+    sut.deleteMultiple = jest.fn();
+    sut.store.srem = jest.fn();
+
+    await sut.batchDeleteWithTags();
+
+    expect(sut.store.srem).toHaveBeenCalledTimes(4);
+    expect(sut.deleteMultiple).toHaveBeenCalledWith(['tag-id-1', 'tag-id-2']);
+  });
 });


### PR DESCRIPTION
This PR adds a `batchDeleteWithTags` utility to the `RedisTaggedCache` class. The purpose of this method is as described in it's docblock, to allow for cache data belonging to a set of tags to be deleted in incremental batches. This method has the same functional purpose as `deleteWithTags`, but it's behavior is different, as it avoids loading all members of a tag set into memory all at once.

The motivation for this addition is to be able to delete large amounts of cache data without having Node run out of memory.